### PR TITLE
Add MongoDB backend server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Spending Tracker
+
+A minimal React web app for tracking expenses and income and visualizing the balance with Highcharts. This project avoids package installation by relying on [esm.sh](https://esm.sh/) CDNs for React and Highcharts.
+The UI now includes simple styling to look closer to a native app.
+
+## Getting Started
+Install dependencies and start the server:
+
+```bash
+npm install
+npm start
+```
+
+The server serves the static React app from the `public` folder and exposes an API at `/api/transactions` backed by MongoDB. Provide a `MONGODB_URI` environment variable or run a local MongoDB instance.
+
+## Development
+Transactions are stored in MongoDB via a small Express server located in `server.js`. The front‑end communicates with this API to fetch and add transactions.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "spendingtracker",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo 'No tests specified' && exit 1"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "highcharts": "^11.4.0",
+    "highcharts-react-official": "^3.2.0",
+    "express": "^4.19.2",
+    "mongoose": "^8.3.3"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Spending Tracker</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div id="root"></div>
+  <script src="../src/index.js" type="module"></script>
+</body>
+</html>

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,44 @@
+body {
+  font-family: Arial, sans-serif;
+  background: #f5f5f5;
+  padding: 20px;
+}
+
+#root {
+  max-width: 600px;
+  margin: 0 auto;
+  background: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+h1 {
+  text-align: center;
+}
+
+form div {
+  margin-bottom: 10px;
+}
+
+.chart-container {
+  margin: 20px 0;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+table th, table td {
+  padding: 8px;
+  border-bottom: 1px solid #ccc;
+}
+
+.income {
+  color: green;
+}
+
+.expense {
+  color: red;
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,46 @@
+const express = require('express');
+const mongoose = require('mongoose');
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+mongoose.connect(process.env.MONGODB_URI || 'mongodb://localhost:27017/spendingtracker', {
+  useNewUrlParser: true,
+  useUnifiedTopology: true,
+});
+
+const txnSchema = new mongoose.Schema({
+  type: { type: String, enum: ['expense', 'income'], required: true },
+  amount: Number,
+  category: String,
+  date: String,
+});
+
+const Transaction = mongoose.model('Transaction', txnSchema);
+
+app.use(express.json());
+app.use(express.static(path.join(__dirname, 'public')));
+
+app.get('/api/transactions', async (req, res) => {
+  try {
+    const txns = await Transaction.find().sort({ date: 1 });
+    res.json(txns);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/api/transactions', async (req, res) => {
+  try {
+    const txn = new Transaction(req.body);
+    await txn.save();
+    res.json(txn);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});

--- a/src/App.js
+++ b/src/App.js
@@ -1,0 +1,41 @@
+import React, { useState, useEffect } from "https://esm.sh/react@18";
+import TransactionForm from "./components/TransactionForm.js";
+import TransactionList from "./components/TransactionList.js";
+import BalanceChart from "./components/BalanceChart.js";
+
+export default function App() {
+  const [transactions, setTransactions] = useState([]);
+
+  useEffect(() => {
+    fetch("/api/transactions")
+      .then((res) => res.json())
+      .then((data) => setTransactions(data))
+      .catch((err) => console.error(err));
+  }, []);
+
+  const addTransaction = (txn) => {
+    fetch("/api/transactions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(txn),
+    })
+      .then((res) => res.json())
+      .then((saved) => setTransactions([...transactions, saved]))
+      .catch((err) => console.error(err));
+  };
+
+  const balance = transactions.reduce(
+    (sum, t) => sum + (t.type === "income" ? t.amount : -t.amount),
+    0
+  );
+
+  return (
+    <div>
+      <h1>Spending Tracker</h1>
+      <h2>Balance: {balance}</h2>
+      <TransactionForm onAdd={addTransaction} />
+      <BalanceChart transactions={transactions} />
+      <TransactionList transactions={transactions} />
+    </div>
+  );
+}

--- a/src/components/BalanceChart.js
+++ b/src/components/BalanceChart.js
@@ -1,0 +1,31 @@
+import React, { useEffect, useRef } from "https://esm.sh/react@18";
+import Highcharts from "https://esm.sh/highcharts";
+
+export default function BalanceChart({ transactions }) {
+  const chartRef = useRef(null);
+
+  useEffect(() => {
+    if (!chartRef.current) return;
+    const dailyTotals = transactions.reduce((acc, t) => {
+      const day = t.date;
+      acc[day] = acc[day] || 0;
+      acc[day] += t.type === "income" ? t.amount : -t.amount;
+      return acc;
+    }, {});
+    const categories = Object.keys(dailyTotals).sort();
+    let running = 0;
+    const data = categories.map((c) => {
+      running += dailyTotals[c];
+      return running;
+    });
+
+    Highcharts.chart(chartRef.current, {
+      title: { text: "Balance Over Time" },
+      xAxis: { categories },
+      yAxis: { title: { text: "Balance" } },
+      series: [{ name: "Balance", data }],
+    });
+  }, [transactions]);
+
+  return <div ref={chartRef} className="chart-container"></div>;
+}

--- a/src/components/TransactionForm.js
+++ b/src/components/TransactionForm.js
@@ -1,0 +1,46 @@
+import React, { useState } from "https://esm.sh/react@18";
+
+export default function TransactionForm({ onAdd }) {
+  const [type, setType] = useState("expense");
+  const [amount, setAmount] = useState(0);
+  const [category, setCategory] = useState("");
+  const [date, setDate] = useState(() => new Date().toISOString().slice(0, 10));
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!amount || !date) return;
+    onAdd({ type, amount: parseFloat(amount), category, date });
+    setAmount(0);
+    setCategory("");
+  };
+
+  return (
+    <form onSubmit={handleSubmit} style={{ marginBottom: 20 }}>
+      <div>
+        <label>
+          Type:
+          <select value={type} onChange={(e) => setType(e.target.value)}>
+            <option value="expense">Expense</option>
+            <option value="income">Income</option>
+          </select>
+        </label>
+      </div>
+      <div>
+        <label>
+          Amount: <input type="number" value={amount} onChange={(e) => setAmount(e.target.value)} />
+        </label>
+      </div>
+      <div>
+        <label>
+          Category: <input type="text" value={category} onChange={(e) => setCategory(e.target.value)} />
+        </label>
+      </div>
+      <div>
+        <label>
+          Date: <input type="date" value={date} onChange={(e) => setDate(e.target.value)} />
+        </label>
+      </div>
+      <button type="submit">Add Transaction</button>
+    </form>
+  );
+}

--- a/src/components/TransactionList.js
+++ b/src/components/TransactionList.js
@@ -1,0 +1,29 @@
+import React from "https://esm.sh/react@18";
+
+export default function TransactionList({ transactions }) {
+  return (
+    <table style={{ width: "100%" }}>
+      <thead>
+        <tr>
+          <th>Date</th>
+          <th>Type</th>
+          <th>Category</th>
+          <th>Amount</th>
+        </tr>
+      </thead>
+      <tbody>
+        {transactions.map((t) => (
+          <tr key={t._id || t.id}>
+            <td>{t.date}</td>
+            <td>{t.type}</td>
+            <td>{t.category}</td>
+            <td className={t.type === "income" ? "income" : "expense"}>
+              {t.type === "income" ? "+" : "-"}
+              {Math.abs(t.amount)}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,5 @@
+import React from "https://esm.sh/react@18";
+import ReactDOM from "https://esm.sh/react-dom@18";
+import App from "./App.js";
+
+ReactDOM.render(<App />, document.getElementById("root"));


### PR DESCRIPTION
## Summary
- implement Express server with MongoDB via Mongoose
- fetch and save transactions through new API
- allow TransactionList to use Mongo IDs
- document server usage in README
- add express and mongoose dependencies

## Testing
- `npm test` *(fails: No tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_685c7aad901c8322a7a9eda5459c7b19